### PR TITLE
searchをlogin以外では非表示

### DIFF
--- a/src/templates/navbar.html
+++ b/src/templates/navbar.html
@@ -12,7 +12,9 @@
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->
+    {% if request.user.is_authenticated %}
     {% include "tweets/search_form.html" %}
+    {% endif %}
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       {% if request.user.is_authenticated %}
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
## WHAT

* ログインしていない、ログインページでsearchが表示されないようにした

## HOW
* navbar.html内に、template条件分を挟んで、request.user.is_authenticatedの真偽で分岐。

## 確認すること

* [ ] 正しい挙動になっていること
    * [ ] 正しく登録できること
    * [ ] すでに登録済みの場合登録できないこと
* [ ] コードに問題がないこと
* [ ] 必要なテストが追加されていること
* [ ] テストがすべてパスしていること
